### PR TITLE
improved matchup algorithm

### DIFF
--- a/aoe-back/controllers/matchup.js
+++ b/aoe-back/controllers/matchup.js
@@ -2,19 +2,17 @@ const router = require('express').Router();
 const Civ = require('../schemas/civ');
 const Unit = require('../schemas/unit');
 
-// Endpoint for returning unit comp based on civs
+// Endpoint for returning the opponent's powerModifier unit with isGoldUnit=true
 router.get('/', async (req, res) => {
   try {
-    const { civ1, civ2 } = req.query;
+    const { oppCivId } = req.query;
+    console.log('Civ:', oppCivId);
 
-    // Fetch both Civ documents and populate their units
-    const [yourCiv, oppCiv] = await Promise.all([
-      Civ.findById(civ1).populate('units.unit'),
-      Civ.findById(civ2).populate('units.unit')
-    ]);
+    // Fetch Civ document and populate its units
+    const oppCiv = await Civ.findById(oppCivId).populate('units.unit');
 
-    if (!yourCiv || !oppCiv) {
-      return res.status(404).json({ message: 'One or both civilizations not found.' });
+    if (!oppCiv) {
+      return res.status(404).json({ message: 'Civilization not found.' });
     }
 
     // Identify highest opponent powerModifier unit with isGoldUnit=true
@@ -26,21 +24,6 @@ router.get('/', async (req, res) => {
       return res.status(404).json({ message: 'No suitable opponent unit found.' });
     }
 
-    // Find the highest powerModifier unit in yourCiv with isGoldUnit=true
-    let yourComp = yourCiv.units
-      .filter(({ unit }) => unit && unit.isGoldUnit && !oppComp.unit.counterOf.includes(unit.id))
-      .sort((a, b) => b.powerModifier - a.powerModifier)[0];
-
-    if (!yourComp) {
-      yourComp = yourCiv.units
-        .filter(({ unit }) => unit && !oppComp.unit.counterOf.includes(unit.id))
-        .sort((a, b) => b.powerModifier - a.powerModifier)[0];
-    }
-
-    if (!yourComp) {
-      return res.status(404).json({ message: 'No suitable unit found for your civilization.' });
-    }
-
     // Convert to desired format
     const formatUnit = ({ unit }) => {
       return unit.toJSON();
@@ -48,40 +31,83 @@ router.get('/', async (req, res) => {
 
     console.log('Opponent Civ:', oppCiv.name);
     console.log('Opponent Power Unit:', formatUnit(oppComp).name);
-    console.log('Your Civ', yourCiv.name);
-    console.log('Your Power Unit:', formatUnit(yourComp).name);
 
-    // Respond with yourComp and oppComp
-    res.json({
-      oppComp: oppComp ? [formatUnit(oppComp)] : [],
-      yourComp: yourComp ? [formatUnit(yourComp)] : []
-    });
+    // Respond with oppComp
+    res.json(oppComp ? [formatUnit(oppComp)] : []);
   } catch (error) {
-    console.error('Error fetching civilizations:', error);
+    console.error('Error fetching civilization:', error);
     res.status(500).json({ message: error.message });
   }
 });
 
+// Endpoint for updating the user's best counter to the opponent's comp
 router.get('/update', async (req, res) => {
   try {
+    // We get IDs of both civs and an array of unit IDs from the request query
     const { yourCiv: yourCivId, oppCiv: oppCivId, oppComp: oppCompIds } = req.query;
 
     // Fetch civs and units from the database
     const yourCiv = await Civ.findById(yourCivId).populate('units.unit');
     const oppCiv = await Civ.findById(oppCivId).populate('units.unit');
-    console.log('Opp civ:', oppCiv);
 
-    const oppComp = await Unit.find({ _id: { $in: oppCompIds } });
-    console.log('Opponent comp:', oppComp);
+    // console.log('Your Units:', yourCiv.units);
+
+    // Here we add powerModifiers to the opponent's units
+    const oppComp = oppCiv.units
+      .filter(({ unit }) => oppCompIds.includes(unit._id.toString()))
+      .map(({ unit, powerModifier }) => ({
+        ...unit._doc,
+        powerModifier
+      }));
 
     // Calculate the average powerModifier of the opponent's comp
     const oppCompPowerModifier = oppComp.reduce((sum, { powerModifier }) => sum + powerModifier, 0) / oppComp.length;
-    console.log('Opponent comp powerModifier:', oppCompPowerModifier);
 
-    // Filter for gold units which have all the opponent units' ids in their counterOf array
+    // Constants
+    const MAX_UNITS = 2;
+    const OPPONENT_UNIT_THRESHOLD = 3;
+    const PM_AVERAGE = 4;
+
+    // Find the highest powerModifier unit with isGoldUnit = True
+    const yourGoldUnit = yourCiv.units
+      .filter(({ unit }) => unit.isGoldUnit)
+      .sort((a, b) => b.powerModifier - a.powerModifier)[0];
+
+    // If opponent only has one unit, return your highest powerModifier gold unit and the highest powerModifier non-gold unit which has the opponent unit's id in it's counterOf array.
+    if (oppComp.length === 1) {
+      const oppUnitId = oppComp[0]._id;
+    
+      const yourGoldUnit = yourCiv.units
+        .filter(({ unit }) => unit.isGoldUnit)
+        .filter(({ unit }) => unit.isMeta)
+        .sort((a, b) => b.powerModifier - a.powerModifier)[0];
+
+      console.log('Your Gold Unit:', yourGoldUnit.unit.name)
+      // If this unit counters the enemy unit, return it
+      if (yourGoldUnit.unit.counterOf.includes(oppUnitId)) {
+        console.log('your power unit is enough')
+        return res.json({ yourComp: [yourGoldUnit.unit.toJSON()] });
+      }
+
+      const yourCounterNonGoldUnit = yourCiv.units
+        .filter(({ unit }) => !unit.isGoldUnit && unit.counterOf.includes(oppUnitId))
+        .sort((a, b) => b.powerModifier - a.powerModifier)[0];
+    
+      if (!yourCounterNonGoldUnit) {
+        console.log('No non-gold unit found that counters the opponent\'s unit');
+      }
+    
+      if (yourGoldUnit && yourCounterNonGoldUnit) {
+        return res.json({ yourComp: [yourGoldUnit.unit.toJSON(), yourCounterNonGoldUnit.unit.toJSON()] });
+      }
+    }
+
+    // Filter for gold units which have all the opponent units' ids in their counterOf array and that are meta and that have reasonable powerModifier
     const yourCounterGoldUnits = yourCiv.units
       .filter(({ unit }) => unit.isGoldUnit)
-      .filter(({ unit }) => oppComp.every(oppUnit => unit.counterOf.includes(oppUnit.id)));
+      .filter(({ unit }) => unit.isMeta)
+      .filter(({ powerModifier }) => powerModifier > PM_AVERAGE)
+      .filter(({ unit }) => oppComp.every(oppUnit => oppUnit.counteredBy.includes(unit.id)));
 
     // If such units exist, return the one with the highest powerModifier
     if (yourCounterGoldUnits.length > 0) {
@@ -90,17 +116,12 @@ router.get('/update', async (req, res) => {
       return res.json({ yourComp: [yourCounterGoldUnit.unit.toJSON()] });
     }
 
-    // Find the highest powerModifier unit with isGoldUnit = True
-    const yourGoldUnit = yourCiv.units
-      .filter(({ unit }) => unit.isGoldUnit)
-      .sort((a, b) => b.powerModifier - a.powerModifier)[0];
-
     // If the id of your highest powerModifier unit which is a gold unit is not in the counterOf array of any of the opponent's units, return this unit
     if (!oppComp.some(oppUnit => oppUnit.counterOf.includes(yourGoldUnit.unit._id))) {
       return res.json({ yourComp: [yourGoldUnit.unit.toJSON()] });
     }
 
-    // If oppComp has more than 3 units, return the highest powerModifier gold unit
+    // If oppComp has more than 3 units, return your highest powerModifier gold unit
     if (oppComp.length > 3) {
       return res.json({ yourComp: [yourGoldUnit.unit.toJSON()] });
     }

--- a/aoe-front/cypress/e2e/buttons_test.cy.js
+++ b/aoe-front/cypress/e2e/buttons_test.cy.js
@@ -12,7 +12,7 @@
 
 describe('unlogged tests', () => {
 
-  beforeEach(function() {
+  beforeEach(function () {
     cy.visit('http://localhost:3000')
     cy.wait(200)
   })
@@ -36,7 +36,7 @@ describe('unlogged tests', () => {
       username: 'reub',
       password: '123123'
     }
-    cy.request('POST', 'http://localhost:3001/api/users/', user) 
+    cy.request('POST', 'http://localhost:3001/api/users/', user)
     cy.wait(500)
     cy.visit('http://localhost:3000')
     cy.wait(500)
@@ -64,7 +64,7 @@ describe('unlogged tests', () => {
     cy.contains('Coreunit')
     cy.contains('Counters to your powerunit')
   })
- 
+
    it('favciv changes correctly', () => {
     cy.wait(500)
     cy.contains('Userinfo').click()
@@ -78,7 +78,7 @@ describe('unlogged tests', () => {
   })
 
 }) */
-/* 
+/*
   it('favciv changes correctly', () => {
     cy.wait(500)
     cy.contains('Userinfo').click()
@@ -125,7 +125,7 @@ describe('login & logout & userinfo', () => {
     cy.contains('login').click()
     cy.wait(100)
     cy.contains('Userinfo').click()
-    cy.contains('Favourite civilization') 
+    cy.contains('Favourite civilization')
     cy.contains('Currently logged in as: reub')
     cy.contains('Logout').click()
     cy.wait(100)
@@ -141,7 +141,7 @@ describe('unlogged, account exists', () => {
       username: 'reub',
       password: '123123'
     }
-    cy.request('POST', 'http://localhost:3001/api/users/', user) 
+    cy.request('POST', 'http://localhost:3001/api/users/', user)
     cy.wait(500)
     cy.visit('http://localhost:3000')
   })

--- a/aoe-front/package-lock.json
+++ b/aoe-front/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.5.0",
         "cross-env": "^7.0.3",
+        "posthog-js": "^1.116.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.3",
@@ -8906,6 +8907,11 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -15432,6 +15438,24 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/posthog-js": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.116.0.tgz",
+      "integrity": "sha512-mSXEnB8W/hgiT8HE8Y0bWlLIM9JSI1e4TlosJL9H4/H/ekDJqL+Yi8JQNWhIefTgUBCU/ZuXmHzs2mO0rbVxhQ==",
+      "dependencies": {
+        "fflate": "^0.4.8",
+        "preact": "^10.19.3"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.19.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.6.tgz",
+      "integrity": "sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -25523,6 +25547,11 @@
         "pend": "~1.2.0"
       }
     },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -30016,6 +30045,20 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "posthog-js": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.116.0.tgz",
+      "integrity": "sha512-mSXEnB8W/hgiT8HE8Y0bWlLIM9JSI1e4TlosJL9H4/H/ekDJqL+Yi8JQNWhIefTgUBCU/ZuXmHzs2mO0rbVxhQ==",
+      "requires": {
+        "fflate": "^0.4.8",
+        "preact": "^10.19.3"
+      }
+    },
+    "preact": {
+      "version": "10.19.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.6.tgz",
+      "integrity": "sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/aoe-front/package.json
+++ b/aoe-front/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.5.0",
     "cross-env": "^7.0.3",
+    "posthog-js": "^1.116.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",

--- a/aoe-front/src/components/analysis/Guide.js
+++ b/aoe-front/src/components/analysis/Guide.js
@@ -6,29 +6,36 @@ import matchupService from '../../services/matchup';
 import './guide.css'
 
 const Guide = () => {
-  const [matchup, setMatchup] = useState(null);
   const [yourComp, setYourComp] = useState([]);
   const [oppComp, setOppComp] = useState([]);
 
   const civs = useSelector(state => state.civs);
   const allCivs = useSelector(state => state.allCivs);
-  const allUnits = useSelector(state => state.allUnits);
 
   const yourCiv = allCivs.find(civ => civ.id === civs.civ1);
   const oppCiv = allCivs.find(civ => civ.id === civs.civ2);
+  console.log('OppCiv:', oppCiv)
 
   const oppUnits = oppCiv.units.map(unitObj => unitObj.unit);
 
   useEffect(() => {
-    const fetchMatchup = async () => {
-      const initialMatchup = await matchupService.getMatchup(civs);
-      setMatchup(initialMatchup);
-      setYourComp(initialMatchup.yourComp);
-      setOppComp(initialMatchup.oppComp);
+    const fetchAndUpdateMatchup = async () => {
+      const oppComp = await matchupService.getMatchup(oppCiv.id);
+      console.log('OppComp:', oppComp);
+      setOppComp(oppComp);
+
+      matchupService.updateMatchup(yourCiv.id, oppCiv.id, oppComp.map(unit => unit.id))
+        .then(response => {
+          setYourComp(response.yourComp);
+          console.log('YourComp:', response.yourComp);
+        })
+        .catch(error => {
+          console.error('Error updating matchup:', error);
+        });
     };
 
-    fetchMatchup();
-  }, [civs]);
+    fetchAndUpdateMatchup();
+  }, [oppCiv.id, yourCiv.id]);
 
   const handleUnitToggle = useCallback((unitId) => {
     const clickedUnit = oppUnits.find(unit => unit.id === unitId);
@@ -36,30 +43,42 @@ const Guide = () => {
       // Check if the clicked unit is already in OppComp
       const isUnitInOppComp = prevOppComp.some(unit => unit.id === unitId);
 
+      let newOppComp;
       if (isUnitInOppComp) {
         // If the unit is already in OppComp, remove it
-        return prevOppComp.filter(unit => unit.id !== unitId);
+        newOppComp = prevOppComp.filter(unit => unit.id !== unitId);
       } else {
         // If the unit isn't in OppComp, add it
-        return [...prevOppComp, clickedUnit];
+        newOppComp = [...prevOppComp, clickedUnit];
       }
+
+      if (newOppComp.length > 0) {
+        matchupService.updateMatchup(yourCiv.id, oppCiv.id, newOppComp.map(unit => unit.id))
+          .then(response => {
+            // Assuming you have a state update function called setYourComp
+            setYourComp(response.yourComp);
+          })
+          .catch(error => {
+            console.error('Error updating matchup:', error);
+          });
+      }
+
+      return newOppComp;
     });
+  }, [oppUnits]);
 
-    // Move the API call inside the useEffect hook
-  }, [oppUnits]); // Add oppUnits to the dependency array
-
-  useEffect(() => {
-    if (oppComp.length > 0) {
-      matchupService.updateMatchup(yourCiv.id, oppCiv.id, oppComp.map(unit => unit.id))
-        .then(response => {
-          // Assuming you have a state update function called setYourComp
-          setYourComp(response.yourComp);
-        })
-        .catch(error => {
-          console.error('Error updating matchup:', error);
-        });
-    }
-  }, [oppComp, yourCiv.id, oppCiv.id]);
+  /*   useEffect(() => {
+      if (oppComp.length > 0) {
+        matchupService.updateMatchup(yourCiv.id, oppCiv.id, oppComp.map(unit => unit.id))
+          .then(response => {
+            // Assuming you have a state update function called setYourComp
+            setYourComp(response.yourComp);
+          })
+          .catch(error => {
+            console.error('Error updating matchup:', error);
+          });
+      }
+    }, [oppComp, yourCiv.id, oppCiv.id]); */
 
   return (
     <div className='content'>

--- a/aoe-front/src/components/analysis/OppCompDisplay.js
+++ b/aoe-front/src/components/analysis/OppCompDisplay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 const OppCompDisplay = ({ oppComp }) => {
+  console.log('OppComp in OppCompDisplay:', oppComp);
   return (
     <div>
       <p>Opponent Unit Composition</p>

--- a/aoe-front/src/components/pages/civchoosing/CivButton.js
+++ b/aoe-front/src/components/pages/civchoosing/CivButton.js
@@ -30,6 +30,7 @@ const CivButton = (props) => {
         onClick={() => buttFunc(id)}
         width={100}
         height={100}/>
+      <p>{name}</p>
     </button>
   )
 }

--- a/aoe-front/src/components/pages/civchoosing/CivButtonHolder.js
+++ b/aoe-front/src/components/pages/civchoosing/CivButtonHolder.js
@@ -5,9 +5,9 @@ const CivButtonHolder = ({ f }) => {
   //const imageNames = Object.keys(images.civImages)
   const civlist = useSelector(state => state.allCivs);
 
-  return(
+  return (
     <div className='civbuttonholder'>
-      {civlist.map((n) => (
+      {[...civlist].sort((a, b) => a.name.localeCompare(b.name)).map((n) => (
         <CivButton
           key={n.id}
           id={n.id}

--- a/aoe-front/src/index.js
+++ b/aoe-front/src/index.js
@@ -16,6 +16,8 @@ import matchupReducer from './reducers/matchupReducer'
 import './main.css'
 import allUnitsReducer from './reducers/allUnitsReducer'
 
+import posthog from 'posthog-js';
+import { PostHogProvider } from 'posthog-js/react'
 
 const store = configureStore({
   reducer: {
@@ -33,8 +35,17 @@ const store = configureStore({
   }
 })
 
+posthog.init(
+  process.env.REACT_APP_PUBLIC_POSTHOG_KEY,
+  {
+    api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
+  }
+);
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <Provider store={store}>
-    <App />
-  </Provider>
+    <PostHogProvider client={posthog}>
+      <App />
+    </PostHogProvider>
+  </Provider >
 )

--- a/aoe-front/src/services/matchup.js
+++ b/aoe-front/src/services/matchup.js
@@ -3,8 +3,8 @@ import axios from '../utils/apiClient';
 const baseUrl = '/api/matchup';
 const updateUrl = '/api/matchup/update';
 
-const getMatchup = async (civs) => {
-  const res = await axios.get(baseUrl, { params: civs });
+const getMatchup = async (oppCivId) => {
+  const res = await axios.get(baseUrl, { params: { oppCivId: oppCivId } });
   return res.data;
 };
 


### PR DESCRIPTION
Muutin vähän tota matchup -apikutsujen logiikkaa. Nyt Guidessa pyydetään ensin yhdellä kutsulla oppComp (tätä endpointtia yksinkertaistin), jonka jälkeen oppCompilla kutsutaan matchup/update -endpointtia.

Tähän endpointtiin tein muutaman lisätsekin. Nyt sieltä pitäisi tulla järkevämpiä ehdotuksia - lähinnä tilanteissa, joissa vastustaja spämmää vaan yhtä unittia.

Tein hups pari muuta juttua ei tähän liittyen, esim. civikuvat aakkosjärjestykseen. Koitin lisätä civien nimet. En tiedä onko hyvä noin vai ei.